### PR TITLE
Add Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.github
+coverage
+dist
+node_modules
+.editorconfig
+.gitignore
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:12-alpine as build
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm ci \
+  && npm run test \
+  && npm run build
+
+FROM node:12-alpine
+
+WORKDIR /app
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV NODE_ENV=production
+
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json .
+COPY --from=build /app/package-lock.json .
+
+RUN npm ci --only=production
+
+ENTRYPOINT ["node", "/app/dist/app.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -611,15 +611,6 @@
         "@types/koa": "*"
       }
     },
-    "@types/koa-logger": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/koa-logger/-/koa-logger-3.1.1.tgz",
-      "integrity": "sha512-wp2HaskkPugfwgXgNnc+idnReuJZSTTYQbkcxXjsMhp1kTc342PxDzTL9FXDgBfEvgt9NX1CCGjkwPKX2dlEKQ==",
-      "dev": true,
-      "requires": {
-        "@types/koa": "*"
-      }
-    },
     "@types/koa-router": {
       "version": "7.0.42",
       "resolved": "https://registry.npmjs.org/@types/koa-router/-/koa-router-7.0.42.tgz",
@@ -779,6 +770,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1115,11 +1107,6 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
-    "bytes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -1177,6 +1164,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1648,7 +1636,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.12.0",
@@ -2623,7 +2612,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -2709,11 +2699,6 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
-    },
-    "humanize-number": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/humanize-number/-/humanize-number-0.0.2.tgz",
-      "integrity": "sha1-EcCvakcWQ2M1iFiASPF5lUFInBg="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -3704,17 +3689,6 @@
         "streaming-json-stringify": "3"
       }
     },
-    "koa-logger": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/koa-logger/-/koa-logger-3.2.1.tgz",
-      "integrity": "sha512-MjlznhLLKy9+kG8nAXKJLM0/ClsQp/Or2vI3a5rbSQmgl8IJBQO0KI5FA70BvW+hqjtxjp49SpH2E7okS6NmHg==",
-      "requires": {
-        "bytes": "^3.1.0",
-        "chalk": "^2.4.2",
-        "humanize-number": "0.0.2",
-        "passthrough-counter": "^1.0.0"
-      }
-    },
     "koa-router": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-7.4.0.tgz",
@@ -4328,11 +4302,6 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
-    },
-    "passthrough-counter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passthrough-counter/-/passthrough-counter-1.0.0.tgz",
-      "integrity": "sha1-GWfZ5m2lcrXAI8eH2xEqOHqxZvo="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -5257,6 +5226,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -5421,8 +5391,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tslint": {
       "version": "5.19.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "koa": "^2.8.1",
     "koa-json": "^2.0.2",
-    "koa-logger": "^3.2.1",
     "koa-router": "^7.4.0",
     "pg": "^7.12.1",
     "winston": "^3.2.1"
@@ -41,7 +40,6 @@
     "@types/jest": "^24.0.18",
     "@types/koa": "^2.0.49",
     "@types/koa-json": "^2.0.18",
-    "@types/koa-logger": "^3.1.1",
     "@types/koa-router": "^7.0.42",
     "@types/pg": "^7.11.2",
     "@types/winston": "^2.4.4",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "koa-json": "^2.0.2",
     "koa-router": "^7.4.0",
     "pg": "^7.12.1",
+    "tslib": "^1.10.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,5 @@
 import Koa from 'koa';
 import Json from 'koa-json';
-import accessLogger from 'koa-logger';
 import Router from 'koa-router';
 
 import { getHealthcheck } from './components/healthcheck';
@@ -22,7 +21,6 @@ privRouter.del('/users/:guid', handle(users.deleteUser));
 app.use(Json());
 app.use(captureErrors);
 app.use(logger);
-app.use(accessLogger());
 app.use(postgres);
 
 app.use(pubRouter.routes());

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,8 +4,9 @@ import Router from 'koa-router';
 
 import { getHealthcheck } from './components/healthcheck';
 import * as users from './components/users';
-import { captureErrors, handle, handleErrors, logger, postgres } from './lib';
+import { captureErrors, handle, handleErrors, logger, postgres, setupLogger } from './lib';
 
+const log = setupLogger();
 const app = new Koa();
 const pubRouter = new Router();
 const privRouter = new Router();
@@ -20,7 +21,7 @@ privRouter.del('/users/:guid', handle(users.deleteUser));
 
 app.use(Json());
 app.use(captureErrors);
-app.use(logger);
+app.use(logger(log));
 app.use(postgres);
 
 app.use(pubRouter.routes());
@@ -31,4 +32,5 @@ app.use(privRouter.allowedMethods());
 
 app.on('error', handleErrors);
 
-app.listen(process.env.PORT || 3000);
+const server = app.listen(process.env.PORT || 3000);
+log.info('starting server', server.address());

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -16,7 +16,7 @@ export async function captureErrors(ctx: Context, next: () => Promise<any>) {
 
 export async function handleErrors(err: any, ctx: Context) {
   const date = new Date();
-  const reference = { reference: `paas-deployments-${date.getTime()}` };
+  const reference = { reference: `looking4mage-api-${date.getTime()}` };
 
   if (err instanceof NotFound) {
     ctx.status = 404;

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,6 +1,6 @@
 import { Context } from 'koa';
 
-import { logger } from './logger';
+import { logger, setupLogger } from './logger';
 
 describe('logger', () => {
   let ctx: {
@@ -11,7 +11,8 @@ describe('logger', () => {
   beforeEach(() => { ctx = {}; });
 
   it('should correctly setup logger', async () => {
-    await logger(ctx as Context, async () => { ctx.status = 200; });
+    const log = setupLogger();
+    await logger(log)(ctx as Context, async () => { ctx.status = 200; });
 
     expect(ctx.log).toBeDefined();
     expect(ctx.log).toHaveProperty('debug');
@@ -23,7 +24,8 @@ describe('logger', () => {
 
   it('should correctly setup logger with DEBUG env variable', async () => {
     process.env.DEBUG = 'true';
-    await logger(ctx as Context, async () => { ctx.status = 200; });
+    const log = setupLogger();
+    await logger(log)(ctx as Context, async () => { ctx.status = 200; });
 
     expect(ctx.log).toBeDefined();
     expect(ctx.log).toHaveProperty('debug');

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,15 +1,21 @@
-import { Context } from 'koa';
+import { Context, Middleware } from 'koa';
 import winston from 'winston';
 
-export async function logger(ctx: Context, next: () => Promise<any>) {
-  ctx.log = winston.createLogger({
-    level: process.env.DEBUG === 'true' ? 'debug' : 'warn',
+export function setupLogger(): winston.Logger {
+  return winston.createLogger({
+    level: process.env.DEBUG === 'true' ? 'debug' : 'info',
     format: winston.format.json(),
-    defaultMeta: { service: 'paas-deployments' },
+    defaultMeta: { service: 'looking4mage-api' },
     transports: [
       new winston.transports.Console(),
     ],
   });
+}
 
-  await next();
+export function logger(log: winston.Logger): Middleware {
+  return async (ctx: Context, next: () => Promise<any>) => {
+    ctx.log = log;
+
+    await next();
+  };
 }


### PR DESCRIPTION
What
----

Removing the Koa Logger

This dependency is almost not customizable, where as we'd like to be
throwing JSON formatted logs into the stdout.

Adding TSLib as dependency

The compiled code relies on this dependency being present in production
environment.

We'd like to be using the logger outside the app context. To achieve
that, we can separate the middleware into two functions:

- "setupLogger" - responsible for getting the instance out
- "logger" - taking the current responsibility of being a middleware and
attaching it to the system

We're also fixing the service name in the logger for the errors to be
represented properly.

We'd like to be able to run a containerised version of the API. This
will allow us to manage the artifact in an efficient way through out the
environment.

We're adding the `.dockerignore` file, where we mean to make the builds
faster by not allowing docker to copy certain files...

How to review
-------------

- Sanity check
- Build: `docker build -t looking4mage/api:latest .`
- Run: `docker run -d -p 3000:3000 looking4mage/api:latest`
- Visit http://localhost:3000/healthcheck and expect response of a sort...
